### PR TITLE
Firewall Scope by Tag

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -9,6 +9,7 @@ resource "digitalocean_firewall" "this" {
       port_range       = inbound_rule.value.port_range
       protocol         = inbound_rule.value.protocol
       source_addresses = inbound_rule.value.source_addresses
+      source_tags      = inbound_rule.value.source_tags
     }
   }
 
@@ -18,6 +19,7 @@ resource "digitalocean_firewall" "this" {
       port_range            = outbound_rule.value.port_range
       protocol              = outbound_rule.value.protocol
       destination_addresses = outbound_rule.value.destination_addresses
+      destination_tags      = outbound_rule.value.destination_tags
     }
   }
 }

--- a/firewall.tf
+++ b/firewall.tf
@@ -1,6 +1,7 @@
 resource "digitalocean_firewall" "this" {
-  name = local.name
-  tags = local.firewall_tags
+  name        = local.name
+  droplet_ids = [digitalocean_droplet.this.id]
+  tags        = local.firewall_tags
 
   dynamic "inbound_rule" {
     for_each = var.inbound_rules

--- a/firewall.tf
+++ b/firewall.tf
@@ -1,6 +1,6 @@
 resource "digitalocean_firewall" "this" {
   name = local.name
-  tags = local.tags
+  tags = local.firewall_tags
 
   dynamic "inbound_rule" {
     for_each = var.inbound_rules

--- a/ip.tf
+++ b/ip.tf
@@ -1,9 +1,9 @@
-resource "digitalocean_floating_ip" "this" {
+resource "digitalocean_reserved_ip" "this" {
   count  = var.floating_ip_enabled ? 1 : 0
   region = var.region
 }
 
-resource "digitalocean_floating_ip_assignment" "this" {
+resource "digitalocean_reserved_ip_assignment" "this" {
   count      = var.floating_ip_enabled ? 1 : 0
   ip_address = digitalocean_floating_ip.this.0.ip_address
   droplet_id = digitalocean_droplet.this.id

--- a/ip.tf
+++ b/ip.tf
@@ -1,10 +1,10 @@
 resource "digitalocean_reserved_ip" "this" {
-  count  = var.floating_ip_enabled ? 1 : 0
+  count  = var.reserved_ip_enabled ? 1 : 0
   region = var.region
 }
 
 resource "digitalocean_reserved_ip_assignment" "this" {
-  count      = var.floating_ip_enabled ? 1 : 0
-  ip_address = digitalocean_floating_ip.this.0.ip_address
+  count      = var.reserved_ip_enabled ? 1 : 0
+  ip_address = digitalocean_reserved_ip.this.0.ip_address
   droplet_id = digitalocean_droplet.this.id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -14,6 +14,11 @@ locals {
     var.tags,
   )
 
+  # remember max number of 5 tags ... keep them simple and sensibly scoped
+  # firewall_tags = compact([for tag in local.tags : contains(["app:", "access:"], tag) ? tag : ""])
+  tag_keys      = [for tag in local.tags : split(":", tag)[0]]
+  firewall_tags = matchkeys(local.tags, local.tag_keys, ["app", "access"])
+
   # ssh firewall controlled by `ssh:true` tag
   ssh_tags = var.ssh_enabled ? ["ssh:true"] : []
 

--- a/locals.tf
+++ b/locals.tf
@@ -15,9 +15,8 @@ locals {
   )
 
   # remember max number of 5 tags ... keep them simple and sensibly scoped
-  # firewall_tags = compact([for tag in local.tags : contains(["app:", "access:"], tag) ? tag : ""])
-  tag_keys      = [for tag in local.tags : split(":", tag)[0]]
-  firewall_tags = matchkeys(local.tags, local.tag_keys, ["app", "access"])
+  # use the `access:` tag key
+  firewall_tags = ["access:${var.name}"]
 
   # ssh firewall controlled by `ssh:true` tag
   ssh_tags = var.ssh_enabled ? ["ssh:true"] : []

--- a/record.tf
+++ b/record.tf
@@ -3,5 +3,5 @@ resource "digitalocean_record" "this" {
   domain = var.domain
   type   = "A"
   name   = var.name
-  value  = var.floating_ip_enabled ? digitalocean_floating_ip.this.0.ip_address : digitalocean_droplet.this.ipv4_address
+  value  = var.reserved_ip_enabled ? digitalocean_reserved_ip.this.0.ip_address : digitalocean_droplet.this.ipv4_address
 }

--- a/~inputs.tf
+++ b/~inputs.tf
@@ -105,7 +105,7 @@ variable domain {
   default = null
 }
 
-variable floating_ip_enabled {
+variable reserved_ip_enabled {
   type    = bool
   default = false
 }
@@ -145,6 +145,7 @@ variable inbound_rules {
     port_range       = string
     protocol         = string
     source_addresses = list(string)
+    source_tags      = list(string)
   }))
   default = {}
 }
@@ -154,6 +155,7 @@ variable outbound_rules {
     port_range            = string
     protocol              = string
     destination_addresses = list(string)
+    destination_tags      = list(string)
   }))
   default = {}
 }

--- a/~outputs.tf
+++ b/~outputs.tf
@@ -2,8 +2,8 @@ output droplet_dnsname {
   value = var.dns_enabled ? digitalocean_record.this.0.fqdn : null
 }
 
-output floating_ip {
-  value = var.floating_ip_enabled ? digitalocean_floating_ip.this.0.ip_address : null
+output reserved_ip {
+  value = var.reserved_ip_enabled ? digitalocean_reserved_ip.this.0.ip_address : null
 }
 
 output droplet_ip {

--- a/~outputs.tf
+++ b/~outputs.tf
@@ -23,6 +23,10 @@ output tags {
   value = local.tags
 }
 
+output firewall_tags {
+  value = local.firewall_tags
+}
+
 output cloudinit_rendered {
   value     = var.cloudinit_enabled ? data.cloudinit_config.this.0.rendered : null
   sensitive = true # inspect state to debug rendered cloudinit parts


### PR DESCRIPTION
- Filtering tags applied to managed firewall are simple and appropriate in granting access to clients.
- Added firewall tags output
- The firewall tags are scoped to permit clients to access the deployment service by adding a tag `access:<service_name>`
- Associate droplet to firewall by droplet id for scoping precision.
- Deprecated floating ip
- Changed floating ip to reserved ip.
